### PR TITLE
added expanded text color to provide more customization

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -131,6 +131,7 @@ These buttons control the next card down!""",
             padding: const EdgeInsets.symmetric(horizontal: 12.0),
             child: ExpansionTileCard(
               key: cardB,
+              expandedTextColor: Colors.red,
               leading: CircleAvatar(child: Text('B')),
               title: Text('Tap me!'),
               subtitle: Text('I expand, too!'),

--- a/lib/expansion_tile_card.dart
+++ b/lib/expansion_tile_card.dart
@@ -47,6 +47,7 @@ class ExpansionTileCard extends StatefulWidget {
     this.contentPadding,
     this.baseColor,
     this.expandedColor,
+    this.expandedTextColor,
     this.duration = const Duration(milliseconds: 200),
     this.elevationCurve = Curves.easeOut,
     this.heightFactorCurve = Curves.easeIn,
@@ -143,6 +144,11 @@ class ExpansionTileCard extends StatefulWidget {
   ///
   /// If null, defaults to Theme.of(context).cardColor.
   final Color expandedColor;
+
+  ///The color of the text of the expended card
+  ///
+  ///If null, defaults to Theme.of(context).accentColor.
+  final Color expandedTextColor;
 
   /// The duration of the expand and collapse animations.
   ///
@@ -328,10 +334,10 @@ class ExpansionTileCardState extends State<ExpansionTileCard>
     final ThemeData theme = Theme.of(context);
     _headerColorTween
       ..begin = theme.textTheme.subtitle1.color
-      ..end = theme.accentColor;
+      ..end = widget.expandedTextColor ?? theme.accentColor;
     _iconColorTween
       ..begin = theme.unselectedWidgetColor
-      ..end = theme.accentColor;
+      ..end = widget.expandedTextColor ?? theme.accentColor;
     _materialColorTween
       ..begin = widget.baseColor ?? theme.canvasColor
       ..end = widget.expandedColor ?? theme.cardColor;


### PR DESCRIPTION
I found myself going in the source code to change the color of the text when the tile is expanded. As of now, the color is set to the accent color provided by the context and there is now way to change it unless you go in you local source code to do it. 

I added a property called `expandedTextColor ` and set its default value to the `accentColor `of the theme.  

so from 

```
  @override
  void didChangeDependencies() {
    final ThemeData theme = Theme.of(context);
    _headerColorTween
      ..begin = theme.textTheme.subtitle1.color
      ..end = theme.accentColor;
    _iconColorTween
      ..begin = theme.unselectedWidgetColor
      ..end = theme.accentColor;
    _materialColorTween
      ..begin = widget.baseColor ?? theme.canvasColor
      ..end = widget.expandedColor ?? theme.cardColor;
    super.didChangeDependencies();
  }
```
 to 

```
final Color expandedTextColor ;

@override
  void didChangeDependencies() {
    final ThemeData theme = Theme.of(context);
    _headerColorTween
      ..begin = theme.textTheme.subtitle1.color
      ..end = widget.expandedTextColor ?? theme.accentColor;
    _iconColorTween
      ..begin = theme.unselectedWidgetColor
      ..end = widget.expandedTextColor ?? theme.accentColor;
    _materialColorTween
      ..begin = widget.baseColor ?? theme.canvasColor
      ..end = widget.expandedColor ?? theme.cardColor;
    super.didChangeDependencies();
  }
```